### PR TITLE
Fix Chronos node type

### DIFF
--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -433,12 +433,12 @@ node_types:
         required: no
         type: integer
     capabilities:
-      job_successor:
+      job:
         type: tosca.capabilities.indigo.Container.Application.Docker.Chronos
         valid_source_types: [tosca.nodes.indigo.Container.Application.Docker.Chronos]
         occurrences: [0, UNBOUNDED]
     requirements:
-      - job_predecessor:
+      - job:
           capability: tosca.capabilities.indigo.Container.Application.Docker.Chronos
           node: tosca.nodes.indigo.Container.Application.Docker.Chronos
           relationship: tosca.relationships.DependsOn


### PR DESCRIPTION
The capabilitis and the requirements of the tosca.nodes.indigo.Container.Application.Docker.Chronos must have the same name.