### PR TITLE
Some fixes for Mesos

### DIFF
--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -340,7 +340,7 @@ node_types:
             galaxy_tool_panel_section_id: { get_property: [ SELF, tool_panel_section_id ] }
 
   tosca.nodes.indigo.ElasticCluster:
-    derived_from: tosca.nodes.Root
+    derived_from: tosca.nodes.SoftwareComponent
     properties:
       secret_token:
         type: string
@@ -587,7 +587,7 @@ node_types:
     interfaces:
       Standard:
         configure:
-          implementation: mesos/mesos_master_install.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/mesos/mesos_master_install.yml
           inputs:
             consul_server_ips: { get_attribute: [ HOST, public_address ] }
             zookeeper_host_list_ips: { get_attribute: [ HOST, public_address ] }
@@ -634,7 +634,7 @@ node_types:
     interfaces:
       Standard:
         create:
-          implementation: mesos/mesos_slave_install.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/mesos/mesos_slave_install.yml
           inputs:
             mesos_master_ips: { get_property: [ SELF, master_ips ] }
             consul_server_ips: { get_property: [ SELF, master_ips ] }
@@ -666,7 +666,7 @@ node_types:
     interfaces:
       Standard:
         create:
-          implementation: mesos/mesos_lb_install.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/mesos/mesos_lb_install.yml
           inputs:
             consul_server_ips: { get_property: [ SELF, master_ips ] }
     requirements:


### PR DESCRIPTION
make ElasticCluster inherits SoftwareComponent instead of Root.
fix mesos script paths.
pass ips as a list to mesos as expected in the recipes.