### PR TITLE
update GalaxyShedTool tosca type

### DIFF
--- a/artifacts/galaxy/galaxy_tools_configure.yml
+++ b/artifacts/galaxy/galaxy_tools_configure.yml
@@ -4,7 +4,7 @@
   gather_facts: False
   pre_tasks:
     - name: Wait Galaxy is up
-      uri: url="http://{{ galaxy_instance_url }}/galaxy/"
+      uri: url="http://{{ instance_public_ip }}/galaxy/"
       register: result
       until: result.status == 200
       retries: 30
@@ -15,7 +15,7 @@
       when: galaxy_flavor != 'galaxy-no-tools'
   vars:
       galaxy_tools_tool_list_files: [ "/tmp/{{ galaxy_flavor }}-tool-list.yml" ]
-      galaxy_tools_galaxy_instance_url: "http://{{ galaxy_instance_url }}/galaxy/"
+      galaxy_tools_galaxy_instance_url: "http://{{ instance_public_ip }}/galaxy/"
       galaxy_tools_api_key: "{{ galaxy_admin_api_key }}"
   roles:
     - { role: indigo-dc.galaxy-tools, when: galaxy_flavor != 'galaxy-no-tools' }

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -344,6 +344,11 @@ node_types:
         description: name of the Galaxy flavor
         required: true
         default: galaxy-no-tools
+      admin_api_key:
+        type: string
+        description: key to access the API with admin role
+        default: not_very_secret_api_key
+        required: false
     requirements:
       - host:
           capability: tosca.capabilities.Container

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -359,7 +359,7 @@ node_types:
         create:
           implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_tools_configure.yml
           inputs:
-            galaxy_flavor: { get_property: [ HOST, flavor ] }
+            galaxy_flavor: { get_property: [ SELF, flavor ] }
             galaxy_admin_api_key: { get_property: [ HOST, admin_api_key ] }
             instance_public_ip: { get_attribute: [ HOST, public_address ] }
 

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -339,18 +339,11 @@ node_types:
   tosca.nodes.indigo.GalaxyShedTool:
     derived_from: tosca.nodes.WebApplication
     properties:
-      name:
+      flavor:
         type: string
-        description: name of the tool
+        description: name of the Galaxy flavor
         required: true
-      owner:
-        type: string
-        description: developer of the tool
-        required: true
-      tool_panel_section_id:
-        type: string
-        description: panel section to install the tool
-        required: true
+        default: galaxy-no-tools
     requirements:
       - host:
           capability: tosca.capabilities.Container
@@ -361,11 +354,9 @@ node_types:
         create:
           implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_tools_configure.yml
           inputs:
-            galaxy_install_path: { get_property: [ HOST, install_path ] }
+            galaxy_flavor: { get_property: [ HOST, flavor ] }
             galaxy_admin_api_key: { get_property: [ HOST, admin_api_key ] }
-            galaxy_tool_name: { get_property: [ SELF, name ] }
-            galaxy_tool_owner: { get_property: [ SELF, owner ] }
-            galaxy_tool_panel_section_id: { get_property: [ SELF, tool_panel_section_id ] }
+            instance_public_ip: { get_attribute: [ HOST, public_address ] }
 
   tosca.nodes.indigo.ElasticCluster:
     derived_from: tosca.nodes.SoftwareComponent

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -62,7 +62,7 @@ topology_template:
     galaxy_tools:
       type: tosca.nodes.indigo.GalaxyShedTool
       properties:
-        galaxy_flavor: { get_input: flavor }
+        flavor: { get_input: flavor }
         admin_api_key: { get_input: admin_api_key }
       requirements:
         - host: galaxy

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2
@@ -41,6 +41,10 @@ topology_template:
       type: string
       description: galaxy instance ssh public key
       default: your_ssh_public_key
+    flavor:
+      type: string
+      description: Galaxy flavor for tools installation
+      default: "galaxy-no-tools"
  
   node_templates:
 
@@ -54,6 +58,14 @@ topology_template:
         instance_key_pub: { get_input: instance_key_pub }
       requirements:
         - lrms: local_lrms
+
+    galaxy_tools:
+      type: tosca.nodes.indigo.GalaxyShedTool
+      properties:
+        galaxy_flavor: { get_input: flavor }
+        admin_api_key: { get_input: admin_api_key }
+      requirements:
+        - host: galaxy
 
     # type to describe a Galaxy not using any LRMS but using the local system
     local_lrms:


### PR DESCRIPTION
Update GalaxyShedTool type.
custom_types: updat GalaxyShedTool type to match indigo-dc.galaxy-tools role
examples/galaxy_tosca.yaml: uptade tosca to install tools
artifact/galaxy/galaxy_tool_configure.yml: chanded {{galaxy_instance_url}} var to {{instance_public_ip}}