### PR TITLE
reference data integration

### DIFF
--- a/artifacts/galaxy/galaxy_redfata_configure.yml
+++ b/artifacts/galaxy/galaxy_redfata_configure.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  connection: local
+  roles:
+    - role: indigo-dc.galaxycloud-refdata
+      galaxy_flavor: "{{ galaxy_flavor }}"
+      get_refdata: "{{ reference_data }}"

--- a/artifacts/galaxy/galaxy_tools_configure.yml
+++ b/artifacts/galaxy/galaxy_tools_configure.yml
@@ -20,3 +20,8 @@
   roles:
     - { role: indigo-dc.galaxy-tools, when: galaxy_flavor != 'galaxy-no-tools' }
 
+
+- hosts: localhost
+  connection: local
+  roles:
+    - { role: indigo-dc.galaxycloud-refdata, galaxy_flavor: "{{ galaxy_flavor }}", get_refdata: "{{ reference_data }}" }

--- a/artifacts/galaxy/galaxy_tools_configure.yml
+++ b/artifacts/galaxy/galaxy_tools_configure.yml
@@ -19,9 +19,3 @@
       galaxy_tools_api_key: "{{ galaxy_admin_api_key }}"
   roles:
     - { role: indigo-dc.galaxy-tools, when: galaxy_flavor != 'galaxy-no-tools' }
-
-
-- hosts: localhost
-  connection: local
-  roles:
-    - { role: indigo-dc.galaxycloud-refdata, galaxy_flavor: "{{ galaxy_flavor }}", get_refdata: "{{ reference_data }}" }

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -349,11 +349,6 @@ node_types:
         description: key to access the API with admin role
         default: not_very_secret_api_key
         required: false
-      reference_data:
-        type: boolean
-        description: Install Reference data
-        default: true
-        required: true
     requirements:
       - host:
           capability: tosca.capabilities.Container
@@ -363,9 +358,6 @@ node_types:
       galaxy_role:
         file: indigo-dc.galaxy-tools,handler-include-static-no
         type: tosca.artifacts.AnsibleGalaxy.role
-      galaxy_role:
-        file: indigo-dc.galaxycloud-refdata
-        type: tosca.artifacts.AnsibleGalaxy.role
     interfaces:
       Standard:
         configure:
@@ -374,7 +366,36 @@ node_types:
             galaxy_flavor: { get_property: [ SELF, flavor ] }
             galaxy_admin_api_key: { get_property: [ HOST, admin_api_key ] }
             instance_public_ip: { get_attribute: [ HOST, public_address, 0 ] }
+
+  tosca.nodes.indigo.GalaxyReferenceData:
+    derived_from: tosca.nodes.WebApplication
+    properties:
+      reference_data:
+        type: boolean
+        description: Install Reference data
+        default: true
+        required: true
+      flavor:
+        type: string
+        description: name of the Galaxy flavor
+        required: true
+        default: galaxy-no-tools
+    requirements:
+      - host:
+          capability: tosca.capabilities.Container
+          node: tosca.nodes.indigo.GalaxyShedTool
+          relationship: tosca.relationships.HostedOn
+    artifacts:
+      galaxy_role:
+        file: indigo-dc.galaxycloud-refdata
+        type: tosca.artifacts.AnsibleGalaxy.role
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_refdata_configure.yml
+          inputs:
             get_refdata: { get_property: [ SELF, reference_data ] }
+            galaxy_flavor: { get_property: [ SELF, flavor ] }
 
   tosca.nodes.indigo.ElasticCluster:
     derived_from: tosca.nodes.SoftwareComponent

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -349,6 +349,11 @@ node_types:
         description: key to access the API with admin role
         default: not_very_secret_api_key
         required: false
+      reference_data:
+        type: boolean
+        description: Install Reference data
+        default: true
+        required: true
     requirements:
       - host:
           capability: tosca.capabilities.Container
@@ -356,7 +361,10 @@ node_types:
           relationship: tosca.relationships.HostedOn
     artifacts:
       galaxy_role:
-        file: indigo-dc.galaxy-tools
+        file: indigo-dc.galaxy-tools,handler-include-static-no
+        type: tosca.artifacts.AnsibleGalaxy.role
+      galaxy_role:
+        file: indigo-dc.galaxycloud-refdata
         type: tosca.artifacts.AnsibleGalaxy.role
     interfaces:
       Standard:
@@ -366,6 +374,7 @@ node_types:
             galaxy_flavor: { get_property: [ SELF, flavor ] }
             galaxy_admin_api_key: { get_property: [ HOST, admin_api_key ] }
             instance_public_ip: { get_attribute: [ HOST, public_address, 0 ] }
+            get_refdata: { get_property: [ SELF, reference_data ] }
 
   tosca.nodes.indigo.ElasticCluster:
     derived_from: tosca.nodes.SoftwareComponent

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -69,9 +69,16 @@ topology_template:
       properties:
         flavor: { get_input: flavor }
         admin_api_key: { get_input: admin_api_key }
-        reference_data: { get_input: reference_data }
       requirements:
         - host: galaxy
+
+    galaxy_refdata:
+      type: tosca.nodes.indigo.GalaxyReferenceData
+      properties:
+        reference_data: { get_input: reference_data }
+        flavor: { get_input: flavor }
+      requirements:
+        - host: galaxy_tools
 
     # type to describe a Galaxy not using any LRMS but using the local system
     local_lrms:

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2
@@ -45,6 +45,11 @@ topology_template:
       type: string
       description: Galaxy flavor for tools installation
       default: "galaxy-no-tools"
+    reference_data:
+      type: boolean
+      description: Install Reference data
+      default: true
+
  
   node_templates:
 
@@ -64,6 +69,7 @@ topology_template:
       properties:
         flavor: { get_input: flavor }
         admin_api_key: { get_input: admin_api_key }
+        reference_data: { get_input: reference_data }
       requirements:
         - host: galaxy
 
@@ -104,7 +110,7 @@ topology_template:
             relationship:
               type: tosca.relationships.AttachesTo
               properties:
-                location: /mnt/disk
+                location: /export
                 device: hdb
 
     my_block_storage:


### PR DESCRIPTION
Changes:
1. GalaxyShedTool type, allowing the end user to install or not the reference data (by default it is true).
2. artifacts/galaxy/galaxy_tools_configure.yml add the role call.
3. examples/galaxy_tosca.yaml : tosca template update.
4. Move external volume disk from /mnt/disk to /export.