### PR TITLE
Onedata and filesystem encryption support

### DIFF
--- a/artifacts/galaxy/galaxy_os_install.yml
+++ b/artifacts/galaxy/galaxy_os_install.yml
@@ -1,0 +1,13 @@
+---
+- hosts: localhost
+  connection: local
+  roles:
+    - role: indigo-dc.galaxycloud-os,
+      isolation_level: "{{ os-storage }}", 
+      GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
+
+    - role: indigo-dc.galaxycloud
+      GALAXY_VERSION: "{{ galaxy_version }}"
+      GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
+      GALAXY_ADMIN_API_KEY: "{{ galaxy_admin_api_key }}"
+      export_dir: /home/galaxy

--- a/artifacts/galaxy/galaxy_os_install.yml
+++ b/artifacts/galaxy/galaxy_os_install.yml
@@ -2,8 +2,8 @@
 - hosts: localhost
   connection: local
   roles:
-    - role: indigo-dc.galaxycloud-os,
-      isolation_level: "{{ os-storage }}", 
+    - role: indigo-dc.galaxycloud-os
+      isolation_level: "{{ os-storage }}"
       GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
 
     - role: indigo-dc.galaxycloud

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -340,7 +340,7 @@ node_types:
       oneprovider:
         type: string
         description: default OneProvider
-        default: "not_a_privder_url"
+        default: "not_a_provider_url"
         required: false
     artifacts:
       galaxy_role:

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -343,7 +343,7 @@ node_types:
         default: "not_a_provider_url"
         required: false
     artifacts:
-      galaxy_role:
+      galaxy_os_role:
         file: indigo-dc.galaxycloud-os
         type: tosca.artifacts.AnsibleGalaxy.role
       galaxy_role:

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -329,7 +329,7 @@ node_types:
     properties:
       storage:
         type: string
-        description: Storage type: Iaas Block Storage (default), Onedaata, Filesystem encryption
+        description: Storage type (Iaas Block Storage (default), Onedaata, Filesystem encryption)
         default: "open"
         requred: true
       token:

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -324,6 +324,48 @@ node_types:
             galaxy_instance_description: { get_property: [ SELF, instance_description ] }
             galaxy_instance_key_pub:  { get_property: [ SELF, instance_key_pub ] }
 
+  tosca.nodes.indigo.GalaxyPortalAndStorage:
+    derived_from: tosca.nodes.indigo.GalaxyPortal
+    properties:
+      storage:
+        type: string
+        description: Storage type: Iaas Block Storage (default), Onedaata, Filesystem encryption
+        default: "open"
+        requred: true
+      token:
+        type: string
+        description: Access token for onedata space
+        default: "not_a_token"
+        required: false
+      oneprovider:
+        type: string
+        description: default OneProvider
+        default: "not_a_privder_url"
+        required: false
+    artifacts:
+      galaxy_role:
+        file: indigo-dc.galaxycloud-os
+        type: tosca.artifacts.AnsibleGalaxy.role
+      galaxy_role:
+        file: indigo-dc.galaxycloud
+        type: tosca.artifacts.AnsibleGalaxy.role
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_os_install.yml
+          inputs:
+            os-storage: { get_property: [ SELF, storage ] }
+            userdata-token: { get_property: [ SELF, token ] }
+            userdata-oneprovider: { get_property: [ SELF, oneprovider ] }
+            galaxy_install_path: { get_property: [ SELF, install_path ] }
+            galaxy_user: { get_property: [ SELF, user ] }
+            galaxy_admin: { get_property: [ SELF, admin_email ] }
+            galaxy_admin_api_key: { get_property: [ SELF, admin_api_key ] }
+            galaxy_lrms: { get_property: [ SELF, lrms, type ] }
+            galaxy_version: { get_property: [ SELF, version ] }
+            galaxy_instance_description: { get_property: [ SELF, instance_description ] }
+            galaxy_instance_key_pub:  { get_property: [ SELF, instance_key_pub ] }
+            
   tosca.nodes.indigo.GalaxyWN:
     derived_from: tosca.nodes.SoftwareComponent
     requirements:

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -41,6 +41,18 @@ topology_template:
       type: string
       description: galaxy instance ssh public key
       default: your_ssh_public_key
+    storage:
+      type: string
+      description: Storage type: Iaas Block Storage (default), Onedaata, Filesystem encryption
+      default: "open"
+    token:
+      type: string
+      description: Access token for onedata space
+      default: "not_a_token"
+    oneprovider:
+      type: string
+      description: default OneProvider
+      default: "not_a_privder_url"
     flavor:
       type: string
       description: Galaxy flavor for tools installation
@@ -54,8 +66,9 @@ topology_template:
   node_templates:
 
     galaxy:
-      type: tosca.nodes.indigo.GalaxyPortal
+      type: tosca.nodes.indigo.GalaxyPortalAndStorage
       properties:
+        storage: { get_input: storage }
         admin_email: { get_input: admin_email }
         admin_api_key: { get_input: admin_api_key }
         version: { get_input: version }

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -43,7 +43,7 @@ topology_template:
       default: your_ssh_public_key
     storage:
       type: string
-      description: Storage type: Iaas Block Storage (default), Onedaata, Filesystem encryption
+      description: Storage type (Iaas Block Storage, Onedaata, Filesystem encryption)
       default: "open"
     token:
       type: string


### PR DESCRIPTION
Added support for indigo-dc.galaxycloud-os role.
3 storage option supported:
open -> IaaS Block Storage
encryption -> Filesystem encryption
onedata -> onadata support.