### PR TITLE
Add Onedata and CernVM-FS support

### DIFF
--- a/artifacts/galaxy/galaxy_redfata_configure.yml
+++ b/artifacts/galaxy/galaxy_redfata_configure.yml
@@ -1,5 +1,10 @@
 ---
 - hosts: localhost
   connection: local
+  pre_tasks:
+    - name: Get refdata-list
+      get_url:
+        url: 'https://raw.githubusercontent.com/indigo-dc/Reference-data-galaxycloud-repository/master/cvmfs_server_keys/{{ refata_cvmfs_key_file }}'
+        dest: '/tmp'
   roles:
     - role: indigo-dc.galaxycloud-refdata

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -428,22 +428,77 @@ node_types:
         description: name of the Galaxy flavor
         required: true
         default: galaxy-no-tools
+      refdata_repository_name:
+        type: string
+        description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
+        default: 'elixir-italy.galaxy.refdata'
+        required: false
+      refdata_provider_type:
+        type: string
+        description: Select Reference data provider type (Onedata, CernVM-FS or download)
+        default: 'onedata'
+        required: false
+      refdata_provider:
+        type: string
+        description: Oneprovider for reference data
+        default: 'not_a_provider'
+        required: false
+      refdata_token:
+        type: string
+        description: Access token for reference data
+        default: 'not_a_token'
+        required: false
+      refdata_cvmfs_server_url:
+        type: string
+        description: CernVM-FS server, replica or stratum-zero
+        default: 'server_url'
+        required: false
+      refdata_cvmfs_key_file:
+        type: string
+        description: CernVM-FS public key
+        default: 'not_a_key'
+        required: false
+      refdata_cvmfs_proxy_url:
+        type: string
+        description: CernVM-FS proxy url
+        default: 'DIRECT'
+        required: false
+      refdata_cvmfs_proxy_port:
+        type: integer 
+        description: CernVM-FS proxy port
+        default: 80
+        required: false
     requirements:
       - host:
           capability: tosca.capabilities.Container
           node: tosca.nodes.indigo.GalaxyPortal
           relationship: tosca.relationships.HostedOn
     artifacts:
+      oneclient_role:
+        file: indigo-dc.oneclient
+        type: tosca.artifacts.AnsibleGalaxy.role
+      cvmfs_role:
+        file: indigo-dc.cvmfs-client
+        type: tosca.artifacts.AnsibleGalaxy.role
       galaxy_role:
         file: indigo-dc.galaxycloud-refdata
         type: tosca.artifacts.AnsibleGalaxy.role
     interfaces:
       Standard:
         configure:
-          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_redfata_configure.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_redfata_configure.yml
           inputs:
             get_refdata: { get_property: [ SELF, reference_data ] }
             galaxy_flavor: { get_property: [ SELF, flavor ] }
+            refdata_repository_name: { get_property: [ SELF, refdata_repository_name ] }
+            refdata_provider_type: { get_property: [ SELF, refdata_provider_type ] }
+            refdata_provider: { get_property: [ SELF, refdata_provider ] }
+            refdata_token: { get_property: [ SELF, refdata_token ] }
+            refdata_cvmfs_server_url: { get_property: [ SELF, refdata_cvmfs_server_url ] }
+            refdata_cvmfs_repository_name: { get_property: [ SELF, refdata_cvmfs_repository_name ] }
+            refdata_cvmfs_key_file: { get_property: [ SELF, refdata_cvmfs_key_file ] }
+            refdata_cvmfs_proxy_url: { get_property: [ SELF, refdata_cvmfs_proxy_url ] }
+            refdata_cvmfs_proxy_port: { get_property: [ SELF, refdata_cvmfs_proxy_port ] }
 
   tosca.nodes.indigo.ElasticCluster:
     derived_from: tosca.nodes.SoftwareComponent

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -453,6 +453,11 @@ node_types:
         description: CernVM-FS server, replica or stratum-zero
         default: 'server_url'
         required: false
+      refdata_cvmfs_repository_name:
+        type: string
+        description: Reference data CernVM-FS repository name
+        default: 'not_a_cvmfs_repository_name'
+        requred: false
       refdata_cvmfs_key_file:
         type: string
         description: CernVM-FS public key

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/mtangaro-galaxy-tools/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/mtangaro-galaxy-tools/tosca-types/master/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2
@@ -61,6 +61,38 @@ topology_template:
       type: boolean
       description: Install Reference data
       default: true
+    refdata_repository_name:
+      type: string
+      description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
+      default: 'elixir-italy.galaxy.refdata'
+    refdata_provider_type:
+      type: string
+      description: Select Reference data provider type (Onedata, CernVM-FS or download)
+      default: 'onedata'
+    refdata_provider:
+      type: string
+      description: Oneprovider for reference data
+      default: 'not_a_provider'
+    refdata_token:
+      type: string
+      description: Access token for reference data
+      default: 'not_a_token'
+    refdata_cvmfs_server_url:
+      type: string
+      description: CernVM-FS server, replica or stratum-zero
+      default: 'server_url'
+    refdata_cvmfs_key_file:
+      type: string
+      description: CernVM-FS public key
+      default: 'not_a_key'
+    refdata_cvmfs_proxy_url:
+      type: string
+      description: CernVM-FS proxy url
+      default: 'DIRECT'
+    refdata_cvmfs_proxy_port:
+      type: integer
+      description: CernVM-FS proxy port
+      default: 80
 
  
   node_templates:
@@ -90,6 +122,15 @@ topology_template:
       properties:
         reference_data: { get_input: reference_data }
         flavor: { get_input: flavor }
+        refdata_repository_name: { get_input: refdata_repository_name }
+        refdata_provider_type: { get_input: refdata_provider_type }
+        refdata_provider: { get_input: refdata_provider }
+        refdata_token: { get_input: refdata_token }
+        refdata_cvmfs_server_url: { get_input: refdata_cvmfs_server_url }
+        refdata_cvmfs_repository_name: { get_input: refdata_cvmfs_repository_name }
+        refdata_cvmfs_key_file: { get_input: refdata_cvmfs_key_file }
+        refdata_cvmfs_proxy_url: { get_input: refdata_cvmfs_proxy_url }
+        refdata_cvmfs_proxy_port: { get_input: refdata_cvmfs_proxy_port }
       requirements:
         - host: galaxy
         - dependency: galaxy_tools

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -81,6 +81,10 @@ topology_template:
       type: string
       description: CernVM-FS server, replica or stratum-zero
       default: 'server_url'
+    refdata_cvmfs_repository_name:
+      type: string
+      description: Reference data CernVM-FS repository name
+      default: 'not_a_cvmfs_repository_name'
     refdata_cvmfs_key_file:
       type: string
       description: CernVM-FS public key


### PR DESCRIPTION
Onedata and cvmfs support

New variables:
refdata_repository_name: This variable set the Onedata space name or cvmfs repository name or the download subdirectory.
refdata_provider_type: 'onedata' (default)
  1. onedata ------> Onedata space with reference data is mounted
  2. cvmfs --------> CernVM-FS repository with reference data is mounted
  3. download -----> Reference data download

- Onedata input options:
refdata_provider_type: 'onedata'
refdata_provider: Oneprovider url
refdata_token: Onedata access token

- CernVM-FS input options:
refdata_provider_type: 'cvmfs'
refdata_cvmfs_server_url: cvmfs url (stratum zero or replica).
refdata_cvmfs_key_file: ssh public kay to access the data
refdata_cvmfs_proxy_url: proxy url, if proxy enabled (default is DIRECT)
refdata_cvmfs_proxy_port: if a proxy url is specified we need the port.

- Download input options (deprecated):
refdata_provider_type: 'download' Enable ref. data download