### PR TITLE
Add ondatea and advanced storage options

### DIFF
--- a/artifacts/galaxy/galaxy_install.yml
+++ b/artifacts/galaxy/galaxy_install.yml
@@ -6,4 +6,3 @@
       GALAXY_VERSION: "{{ galaxy_version }}"
       GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
       GALAXY_ADMIN_API_KEY: "{{ galaxy_admin_api_key }}"
-      export_dir: /home/galaxy

--- a/artifacts/galaxy/galaxy_os_install.yml
+++ b/artifacts/galaxy/galaxy_os_install.yml
@@ -9,4 +9,4 @@
       GALAXY_VERSION: "{{ galaxy_version }}"
       GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
       GALAXY_ADMIN_API_KEY: "{{ galaxy_admin_api_key }}"
-      export_dir: /home/galaxy
+      enable_storage_advanced_options: true # true only with indigo-dc.galaxycloud-os

--- a/artifacts/galaxy/galaxy_os_install.yml
+++ b/artifacts/galaxy/galaxy_os_install.yml
@@ -3,7 +3,6 @@
   connection: local
   roles:
     - role: indigo-dc.galaxycloud-os
-      isolation_level: "{{ os_storage }}"
       GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
 
     - role: indigo-dc.galaxycloud

--- a/artifacts/galaxy/galaxy_redfata_configure.yml
+++ b/artifacts/galaxy/galaxy_redfata_configure.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - name: Get refdata-list
       get_url:
-        url: 'https://raw.githubusercontent.com/indigo-dc/Reference-data-galaxycloud-repository/master/cvmfs_server_keys/{{ refata_cvmfs_key_file }}'
+        url: 'https://raw.githubusercontent.com/indigo-dc/Reference-data-galaxycloud-repository/master/cvmfs_server_keys/{{ refdata_cvmfs_key_file }}'
         dest: '/tmp'
   roles:
     - role: indigo-dc.galaxycloud-refdata

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -333,7 +333,7 @@ node_types:
   tosca.nodes.indigo.GalaxyPortalAndStorage:
     derived_from: tosca.nodes.indigo.GalaxyPortal
     properties:
-      storage:
+      os_storage:
         type: string
         description: Storage type (Iaas Block Storage (default), Onedaata, Filesystem encryption)
         default: "open"
@@ -343,12 +343,20 @@ node_types:
         description: Access token for onedata space
         default: "not_a_token"
         required: false
-      oneprovider:
+      provider:
         type: string
         description: default OneProvider
         default: "not_a_provider_url"
         required: false
+      space:
+        type: string
+        description: Onedata space
+        default: "galaxy"
+        required: false
     artifacts:
+      oneclient_role:
+        file: indigo-dc.oneclient
+        type: tosca.artifacts.AnsibleGalaxy.role
       galaxy_os_role:
         file: indigo-dc.galaxycloud-os
         type: tosca.artifacts.AnsibleGalaxy.role
@@ -358,11 +366,12 @@ node_types:
     interfaces:
       Standard:
         configure:
-          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_os_install.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_os_install.yml
           inputs:
-            os_storage: { get_property: [ SELF, storage ] }
+            os_storage: { get_property: [ SELF, os_storage ] }
             userdata_token: { get_property: [ SELF, token ] }
-            userdata_oneprovider: { get_property: [ SELF, oneprovider ] }
+            userdata_oneprovider: { get_property: [ SELF, provider ] }
+            userdata_space: { get_property: [ SELF, space ] }
             galaxy_install_path: { get_property: [ SELF, install_path ] }
             galaxy_user: { get_property: [ SELF, user ] }
             galaxy_admin: { get_property: [ SELF, admin_email ] }

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2
@@ -41,18 +41,22 @@ topology_template:
       type: string
       description: galaxy instance ssh public key
       default: your_ssh_public_key
-    storage:
+    galaxy_storage_type:
       type: string
       description: Storage type (Iaas Block Storage, Onedaata, Filesystem encryption)
-      default: "open"
-    token:
-      type: string
-      description: Access token for onedata space
-      default: "not_a_token"
-    oneprovider:
+      default: "IaaS"
+    userdata_provider:
       type: string
       description: default OneProvider
       default: "not_a_privder_url"
+    userdata_token:
+      type: string
+      description: Access token for onedata space
+      default: "not_a_token"
+    userdata_space:
+      type: string
+      description: Onedata space
+      default: "galaxy"
     flavor:
       type: string
       description: Galaxy flavor for tools installation
@@ -104,7 +108,10 @@ topology_template:
     galaxy:
       type: tosca.nodes.indigo.GalaxyPortalAndStorage
       properties:
-        storage: { get_input: storage }
+        os_storage: { get_input: galaxy_storage_type }
+        token: { get_input: userdata_token }
+        provider: { get_input: userdata_provider }
+        space: { get_input: userdata_space }
         admin_email: { get_input: admin_email }
         admin_api_key: { get_input: admin_api_key }
         version: { get_input: version }


### PR DESCRIPTION
- Change variable name from isolation_level to os_storage for IM contextualization
- add onedata space variable
- remove export_dir from artifact: configuration entrusted to ansible