### PR TITLE
Galaxy fast-config and tooldeps role integration

### DIFF
--- a/artifacts/galaxy/galaxy_fastconfig.yml
+++ b/artifacts/galaxy/galaxy_fastconfig.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  connection: local
+  roles:
+    - role: indigo-dc.galaxycloud-os
+      GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
+      tool_deps_path: '/home/galaxy/tool_deps' # fixed due to galaxy image configuration
+
+    - role: indigo-dc.galaxycloud-fastconfig
+      GALAXY_VERSION: "{{ galaxy_version }}"
+      GALAXY_ADMIN_EMAIL: "{{ galaxy_admin }}"
+      GALAXY_ADMIN_API_KEY: "{{ galaxy_admin_api_key }}"
+      tool_deps_path: '/home/galaxy/tool_deps' # fixed due to galaxy image configuration
+      conda_prefix: '/home/galaxy/galaxy/tool_deps/_conda' # fixed due to galaxy image configuration
+      enable_storage_advanced_options: true # true only with indigo-dc.galaxycloud-os

--- a/artifacts/galaxy/galaxy_redfata_configure.yml
+++ b/artifacts/galaxy/galaxy_redfata_configure.yml
@@ -6,5 +6,6 @@
       get_url:
         url: 'https://raw.githubusercontent.com/indigo-dc/Reference-data-galaxycloud-repository/master/cvmfs_server_keys/{{ refdata_cvmfs_key_file }}'
         dest: '/tmp'
+      when: refdata_provider_type == 'cvmfs'
   roles:
     - role: indigo-dc.galaxycloud-refdata

--- a/artifacts/galaxy/galaxy_tools_configure.yml
+++ b/artifacts/galaxy/galaxy_tools_configure.yml
@@ -19,3 +19,4 @@
       galaxy_tools_api_key: "{{ galaxy_admin_api_key }}"
   roles:
     - { role: indigo-dc.galaxy-tools, when: galaxy_flavor != 'galaxy-no-tools' }
+    - { role: indigo-dc.galaxycloud-tooldeps, galaxy_instance_url: 'http://{{ instance_public_ip }}/galaxy/' }

--- a/artifacts/galaxy/galaxy_wn_configure.yml
+++ b/artifacts/galaxy/galaxy_wn_configure.yml
@@ -16,3 +16,6 @@
     
     - name: Add the authorized_key to the user {{galaxy_user}}
       authorized_key: user={{galaxy_user}} key="{{ lookup('file', '/tmp/' + galaxy_user + '_id_rsa.pub') }}"
+
+  roles:
+    - { role: indigo-dc.galaxycloud-tooldeps, check_galaxy: false }

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -402,6 +402,60 @@ node_types:
             galaxy_instance_description: { get_property: [ SELF, instance_description ] }
             galaxy_instance_key_pub:  { get_property: [ SELF, instance_key_pub ] }
             export_dir: { get_property: [ SELF, export_dir ] }
+
+  tosca.nodes.indigo.GalaxyPortalFastConfig:
+    derived_from: tosca.nodes.indigo.GalaxyPortalAndStorage
+    properties:
+      flavor:
+        type: string
+        description: name of the Galaxy flavor
+        required: true
+        default: galaxy-no-tools
+      os_storage:
+        type: string
+        description: Storage type (Iaas Block Storage (default), Onedaata, Filesystem encryption)
+        default: "IaaS"
+        required: true
+      token:
+        type: string
+        description: Access token for onedata space
+        default: "not_a_token"
+        required: false
+      provider:
+        type: string
+        description: default OneProvider
+        default: "not_a_provider_url"
+        required: false
+      space:
+        type: string
+        description: Onedata space
+        default: "galaxy"
+        required: false
+    artifacts:
+      galaxy_os_role:
+        file: indigo-dc.galaxycloud-os
+        type: tosca.artifacts.AnsibleGalaxy.role
+      galaxy_role:
+        file: indigo-dc.galaxycloud-fastconfig
+        type: tosca.artifacts.AnsibleGalaxy.role
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_fastconfig.yml
+          inputs:
+            os_storage: { get_property: [ SELF, os_storage ] }
+            userdata_token: { get_property: [ SELF, token ] }
+            userdata_oneprovider: { get_property: [ SELF, provider ] }
+            userdata_space: { get_property: [ SELF, space ] }
+            galaxy_install_path: { get_property: [ SELF, install_path ] }
+            galaxy_user: { get_property: [ SELF, user ] }
+            galaxy_admin: { get_property: [ SELF, admin_email ] }
+            galaxy_admin_api_key: { get_property: [ SELF, admin_api_key ] }
+            galaxy_lrms: { get_property: [ SELF, lrms, type ] }
+            galaxy_version: { get_property: [ SELF, version ] }
+            galaxy_instance_description: { get_property: [ SELF, instance_description ] }
+            galaxy_instance_key_pub:  { get_property: [ SELF, instance_key_pub ] }
+            export_dir: { get_property: [ SELF, export_dir ] }
  
   tosca.nodes.indigo.GalaxyWN:
     derived_from: tosca.nodes.SoftwareComponent

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -432,10 +432,13 @@ node_types:
         default: "galaxy"
         required: false
     artifacts:
+      oneclient_role:
+        file: indigo-dc.oneclient
+        type: tosca.artifacts.AnsibleGalaxy.role
       galaxy_os_role:
         file: indigo-dc.galaxycloud-os
         type: tosca.artifacts.AnsibleGalaxy.role
-      galaxy_role:
+      galaxy_role-fastconfig:
         file: indigo-dc.galaxycloud-fastconfig
         type: tosca.artifacts.AnsibleGalaxy.role
     interfaces:

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -494,6 +494,9 @@ node_types:
       galaxy_role:
         file: indigo-dc.galaxy-tools,master
         type: tosca.artifacts.AnsibleGalaxy.role
+      tooldeps_role:
+        file: indigo-dc.galaxycloud-tooldeps
+        type: tosca.artifacts.AnsibleGalaxy.role
     interfaces:
       Standard:
         configure:

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -500,7 +500,7 @@ node_types:
     interfaces:
       Standard:
         configure:
-          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_tools_configure.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/artifacts/galaxy/galaxy_tools_configure.yml
           inputs:
             galaxy_flavor: { get_property: [ SELF, flavor ] }
             galaxy_admin_api_key: { get_property: [ HOST, admin_api_key ] }

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Virtual Elastic Cluster. It will launch

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -1,26 +1,49 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
 
 description: >
-  TOSCA test for launching a Galaxy Server also configuring the bowtie2
-  tool using Galaxy Tool Shed.
+  TOSCA test for launching a Virtual Elastic Cluster. It will launch
+  a single front-end that will be in change of managing the elasticity
+  using the specified LRMS (torque, sge, slurm and condor) workload.
 
 topology_template:
   inputs:
-    number_cpus:
+    wn_num:
       type: integer
-      description: number of cpus required for the instance
+      description: Maximum number of WNs in the elastic cluster
+      default: 5
+      required: yes
+    fe_cpus:
+      type: integer
+      description: Numer of CPUs for the front-end node
       default: 1
-    memory_size:
-      type: string
-      description: ram memory required for the instance
+      required: yes
+    fe_mem:
+      type: scalar-unit.size
+      description: Amount of Memory for the front-end node
       default: 1 GB
+      required: yes
+    wn_cpus:
+      type: integer
+      description: Numer of CPUs for the WNs
+      default: 1
+      required: yes
+    wn_mem:
+      type: scalar-unit.size
+      description: Amount of Memory for the WNs
+      default: 1 GB
+      required: yes
     storage_size:
       type: string
       description: storage memory required for the instance
-      default: 10 GB      
+      default: 10 GB
+    hybrid:
+      type: boolean
+      description: Flag to specify that this cluster will work in an hybrid environment
+      default: false
+      required: false
 
     admin_email:
       type: string
@@ -30,10 +53,6 @@ topology_template:
       type: string
       description: key to access the API with admin role
       default: not_very_secret_api_key
-    user:
-      type: string
-      description: username to launch the galaxy daemon
-      default: galaxy
     version:
       type: string
       description: galaxy version to install
@@ -41,7 +60,7 @@ topology_template:
     instance_description:
       type: string
       description: galaxy instance description
-      default: "INDIGO Galaxy test"
+      default: INDIGO Galaxy test
     instance_key_pub:
       type: string
       description: galaxy instance ssh public key
@@ -49,24 +68,7 @@ topology_template:
     export_dir:
       type: string
       description: path to store galaxy data
-      default: /export
-
-    galaxy_storage_type:
-      type: string
-      description: Storage type (Iaas Block Storage, Onedaata, Filesystem encryption)
-      default: "IaaS"
-    userdata_provider:
-      type: string
-      description: default OneProvider
-      default: "not_a_privder_url"
-    userdata_token:
-      type: string
-      description: Access token for onedata space
-      default: "not_a_token"
-    userdata_space:
-      type: string
-      description: Onedata space
-      default: "galaxy"
+      default: /home/export
 
     flavor:
       type: string
@@ -80,7 +82,7 @@ topology_template:
     refdata_dir:
       type: string
       description: path to store galaxy reference data
-      default: /refdata
+      default: /home/refdata
     refdata_repository_name:
       type: string
       description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
@@ -118,16 +120,24 @@ topology_template:
       description: CernVM-FS proxy port
       default: 80
 
- 
+
   node_templates:
 
-    galaxy:
-      type: tosca.nodes.indigo.GalaxyPortalAndStorage
+    elastic_cluster_front_end:
+      type: tosca.nodes.indigo.ElasticCluster
       properties:
-        os_storage: { get_input: galaxy_storage_type }
-        token: { get_input: userdata_token }
-        provider: { get_input: userdata_provider }
-        space: { get_input: userdata_space }
+        deployment_id: orchestrator_deployment_id
+        iam_access_token: iam_access_token
+        iam_clues_client_id: iam_clues_client_id
+        iam_clues_client_secret: iam_clues_client_secret
+        hybrid: { get_input: hybrid }
+      requirements:
+        - lrms: lrms_front_end
+        - wn: wn_node
+
+    galaxy_portal:
+      type: tosca.nodes.indigo.GalaxyPortal
+      properties:
         admin_email: { get_input: admin_email }
         admin_api_key: { get_input: admin_api_key }
         version: { get_input: version }
@@ -135,7 +145,15 @@ topology_template:
         instance_key_pub: { get_input: instance_key_pub }
         export_dir: { get_input: export_dir }
       requirements:
-        - lrms: local_lrms
+        - lrms: lrms_front_end
+
+    galaxy_tools:
+      type: tosca.nodes.indigo.GalaxyShedTool
+      properties:
+        flavor: { get_input: flavor }
+        admin_api_key: { get_input: admin_api_key }
+      requirements:
+        - host: galaxy_portal
 
     galaxy_refdata:
       type: tosca.nodes.indigo.GalaxyReferenceData
@@ -153,19 +171,23 @@ topology_template:
         refdata_cvmfs_proxy_url: { get_input: refdata_cvmfs_proxy_url }
         refdata_cvmfs_proxy_port: { get_input: refdata_cvmfs_proxy_port }
       requirements:
-        - host: galaxy
+        - host: galaxy_portal
+        - dependency: galaxy_tools
 
-    # type to describe a Galaxy not using any LRMS but using the local system
-    local_lrms:
-      type: tosca.nodes.indigo.LRMS.FrontEnd.Local
+    lrms_front_end:
+      type: tosca.nodes.indigo.LRMS.FrontEnd.Slurm
+      properties:
+        wn_ips: { get_attribute: [ lrms_wn, private_address ] }
+        hybrid: { get_input: hybrid }
       requirements:
-        - host: galaxy_server
- 
-    galaxy_server:
+        - host: lrms_server
+
+    lrms_server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
           properties:
+            dns_name: slurmserver
             network_name: PUBLIC
             ports:
               http_port:
@@ -174,15 +196,16 @@ topology_template:
               ftp_port:
                 protocol: tcp
                 source: 21
-        # Host container properties
         host:
-         properties:
-           num_cpus: { get_input: number_cpus }
-           mem_size: { get_input: memory_size }
-        # Guest Operating System properties
+          properties:
+            num_cpus: { get_input: fe_cpus }
+            mem_size: { get_input: fe_mem }
         os:
           properties:
-            image: { concat: ['centos_', get_input: flavor, '_vmi',] } # centos_galaxy-no-tools_vmi
+            type: linux
+            distribution: centos
+            version: 7.2
+            image: indigodatacloudapps/galaxy
       requirements:
         # contextually this can only be a relationship type
         - local_storage:
@@ -200,6 +223,46 @@ topology_template:
       properties:
         size: { get_input: storage_size }
 
+    wn_node:
+      type: tosca.nodes.indigo.LRMS.WorkerNode.Slurm
+      properties:
+        front_end_ip: { get_attribute: [ lrms_server, private_address, 0 ] }
+        public_front_end_ip: { get_attribute: [ lrms_server, public_address, 0 ] }
+        hybrid: { get_input: hybrid }
+      capabilities:
+        wn:
+          properties:
+            max_instances: { get_input: wn_num }
+            min_instances: 0
+      requirements:
+        - host: lrms_wn
+
+    galaxy_wn:
+      type: tosca.nodes.indigo.GalaxyWN
+      requirements:
+        - host: lrms_wn
+
+    lrms_wn:
+      type: tosca.nodes.indigo.Compute
+      capabilities:
+        scalable:
+          properties:
+            count: 0
+        host:
+          properties:
+            num_cpus: { get_input: wn_cpus }
+            mem_size: { get_input: wn_mem }
+        os:
+          properties:
+            type: linux
+            distribution: centos
+            version: 7.2
+            image: indigodatacloudapps/galaxy
+
   outputs:
     galaxy_url:
-      value: { concat: [ 'http://', get_attribute: [ galaxy_server, public_address, 0 ], '/galaxy' ] }
+      value: { concat: [ 'http://', get_attribute: [ lrms_server, public_address, 0 ], '/galaxy' ] }
+    cluster_ip:
+      value: { get_attribute: [ lrms_server, public_address, 0 ] }
+    cluster_creds:
+      value: { get_attribute: [ lrms_server, endpoint, credential, 0 ] }

--- a/examples/galaxy_elixirIT_fastconfig.yaml
+++ b/examples/galaxy_elixirIT_fastconfig.yaml
@@ -182,7 +182,7 @@ topology_template:
         # Guest Operating System properties
         os:
           properties:
-            image: { concat: ['centos_', get_input: flavor, '_vmi',] } # centos_galaxy-no-tools_vmi
+            image: { concat: ['centos_', get_input: flavor, '_vmi'] } # centos_galaxy-no-tools_vmi
       requirements:
         # contextually this can only be a relationship type
         - local_storage:

--- a/examples/galaxy_elixirIT_fastconfig.yaml
+++ b/examples/galaxy_elixirIT_fastconfig.yaml
@@ -1,0 +1,202 @@
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+imports:
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
+
+description: >
+  TOSCA test for launching a Galaxy Server also configuring the bowtie2
+  tool using Galaxy Tool Shed.
+
+topology_template:
+  inputs:
+    number_cpus:
+      type: integer
+      description: number of cpus required for the instance
+      default: 1
+    memory_size:
+      type: string
+      description: ram memory required for the instance
+      default: 1 GB
+    storage_size:
+      type: string
+      description: storage memory required for the instance
+      default: 10 GB      
+
+    admin_email:
+      type: string
+      description: email of the admin user
+      default: admin@admin.com
+    admin_api_key:
+      type: string
+      description: key to access the API with admin role
+      default: not_very_secret_api_key
+    user:
+      type: string
+      description: username to launch the galaxy daemon
+      default: galaxy
+    version:
+      type: string
+      description: galaxy version to install
+      default: master
+    instance_description:
+      type: string
+      description: galaxy instance description
+      default: "INDIGO Galaxy test"
+    instance_key_pub:
+      type: string
+      description: galaxy instance ssh public key
+      default: your_ssh_public_key
+    export_dir:
+      type: string
+      description: path to store galaxy data
+      default: /export
+
+    galaxy_storage_type:
+      type: string
+      description: Storage type (Iaas Block Storage, Onedaata, Filesystem encryption)
+      default: "IaaS"
+    userdata_provider:
+      type: string
+      description: default OneProvider
+      default: "not_a_privder_url"
+    userdata_token:
+      type: string
+      description: Access token for onedata space
+      default: "not_a_token"
+    userdata_space:
+      type: string
+      description: Onedata space
+      default: "galaxy"
+
+    flavor:
+      type: string
+      description: Galaxy flavor for tools installation
+      default: "galaxy-no-tools"
+
+    reference_data:
+      type: boolean
+      description: Install Reference data
+      default: true
+    refdata_dir:
+      type: string
+      description: path to store galaxy reference data
+      default: /refdata
+    refdata_repository_name:
+      type: string
+      description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
+      default: 'elixir-italy.galaxy.refdata'
+    refdata_provider_type:
+      type: string
+      description: Select Reference data provider type (Onedata, CernVM-FS or download)
+      default: 'onedata'
+    refdata_provider:
+      type: string
+      description: Oneprovider for reference data
+      default: 'not_a_provider'
+    refdata_token:
+      type: string
+      description: Access token for reference data
+      default: 'not_a_token'
+    refdata_cvmfs_server_url:
+      type: string
+      description: CernVM-FS server, replica or stratum-zero
+      default: 'server_url'
+    refdata_cvmfs_repository_name:
+      type: string
+      description: Reference data CernVM-FS repository name
+      default: 'not_a_cvmfs_repository_name'
+    refdata_cvmfs_key_file:
+      type: string
+      description: CernVM-FS public key
+      default: 'not_a_key'
+    refdata_cvmfs_proxy_url:
+      type: string
+      description: CernVM-FS proxy url
+      default: 'DIRECT'
+    refdata_cvmfs_proxy_port:
+      type: integer
+      description: CernVM-FS proxy port
+      default: 80
+
+ 
+  node_templates:
+
+    galaxy:
+      type: tosca.nodes.indigo.GalaxyPortalAndStorage
+      properties:
+        os_storage: { get_input: galaxy_storage_type }
+        token: { get_input: userdata_token }
+        provider: { get_input: userdata_provider }
+        space: { get_input: userdata_space }
+        admin_email: { get_input: admin_email }
+        admin_api_key: { get_input: admin_api_key }
+        version: { get_input: version }
+        instance_description: { get_input: instance_description }
+        instance_key_pub: { get_input: instance_key_pub }
+        export_dir: { get_input: export_dir }
+      requirements:
+        - lrms: local_lrms
+
+    galaxy_refdata:
+      type: tosca.nodes.indigo.GalaxyReferenceData
+      properties:
+        reference_data: { get_input: reference_data }
+        refdata_dir: { get_input: refdata_dir }
+        flavor: { get_input: flavor }
+        refdata_repository_name: { get_input: refdata_repository_name }
+        refdata_provider_type: { get_input: refdata_provider_type }
+        refdata_provider: { get_input: refdata_provider }
+        refdata_token: { get_input: refdata_token }
+        refdata_cvmfs_server_url: { get_input: refdata_cvmfs_server_url }
+        refdata_cvmfs_repository_name: { get_input: refdata_cvmfs_repository_name }
+        refdata_cvmfs_key_file: { get_input: refdata_cvmfs_key_file }
+        refdata_cvmfs_proxy_url: { get_input: refdata_cvmfs_proxy_url }
+        refdata_cvmfs_proxy_port: { get_input: refdata_cvmfs_proxy_port }
+      requirements:
+        - host: galaxy
+
+    # type to describe a Galaxy not using any LRMS but using the local system
+    local_lrms:
+      type: tosca.nodes.indigo.LRMS.FrontEnd.Local
+      requirements:
+        - host: galaxy_server
+ 
+    galaxy_server:
+      type: tosca.nodes.indigo.Compute
+      capabilities:
+        endpoint:
+          properties:
+            network_name: PUBLIC
+            ports:
+              http_port:
+                protocol: tcp
+                source: 80
+        # Host container properties
+        host:
+         properties:
+           num_cpus: { get_input: number_cpus }
+           mem_size: { get_input: memory_size }
+        # Guest Operating System properties
+        os:
+          properties:
+            image: { concat: ['centos_', get_input: flavor, '_vmi',] } # centos_galaxy-no-tools_vmi
+      requirements:
+        # contextually this can only be a relationship type
+        - local_storage:
+            # capability is provided by Compute Node Type
+            node: my_block_storage
+            capability: tosca.capabilities.Attachment
+            relationship:
+              type: tosca.relationships.AttachesTo
+              properties:
+                location: { get_input: export_dir }
+                device: hdb
+
+    my_block_storage:
+      type: tosca.nodes.BlockStorage
+      properties:
+        size: { get_input: storage_size }
+
+  outputs:
+    galaxy_url:
+      value: { concat: [ 'http://', get_attribute: [ galaxy_server, public_address, 0 ], '/galaxy' ] }

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -17,6 +17,11 @@ topology_template:
       type: string
       description: ram memory required for the instance
       default: 1 GB
+    storage_size:
+      type: string
+      description: storage memory required for the instance
+      default: 10 GB      
+
     admin_email:
       type: string
       description: email of the admin user
@@ -41,6 +46,11 @@ topology_template:
       type: string
       description: galaxy instance ssh public key
       default: your_ssh_public_key
+    export_dir:
+      type: string
+      description: path to store galaxy data
+      default: /export
+
     galaxy_storage_type:
       type: string
       description: Storage type (Iaas Block Storage, Onedaata, Filesystem encryption)
@@ -57,14 +67,20 @@ topology_template:
       type: string
       description: Onedata space
       default: "galaxy"
+
     flavor:
       type: string
       description: Galaxy flavor for tools installation
       default: "galaxy-no-tools"
+
     reference_data:
       type: boolean
       description: Install Reference data
       default: true
+    refdata_dir:
+      type: string
+      description: path to store galaxy reference data
+      default: /refdata
     refdata_repository_name:
       type: string
       description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
@@ -117,6 +133,7 @@ topology_template:
         version: { get_input: version }
         instance_description: { get_input: instance_description }
         instance_key_pub: { get_input: instance_key_pub }
+        export_dir: { get_input: export_dir }
       requirements:
         - lrms: local_lrms
 
@@ -132,6 +149,7 @@ topology_template:
       type: tosca.nodes.indigo.GalaxyReferenceData
       properties:
         reference_data: { get_input: reference_data }
+        refdata_dir: { get_input: refdata_dir }
         flavor: { get_input: flavor }
         refdata_repository_name: { get_input: refdata_repository_name }
         refdata_provider_type: { get_input: refdata_provider_type }
@@ -162,6 +180,9 @@ topology_template:
               http_port:
                 protocol: tcp
                 source: 80
+              ftp_port:
+                protocol: tcp
+                source: 21
         # Host container properties
         host:
          properties:
@@ -183,13 +204,13 @@ topology_template:
             relationship:
               type: tosca.relationships.AttachesTo
               properties:
-                location: /export
+                location: { get_input: export_dir }
                 device: hdb
 
     my_block_storage:
       type: tosca.nodes.BlockStorage
       properties:
-        size: 10 GB
+        size: { get_input: storage_size }
 
   outputs:
     galaxy_url:

--- a/examples/galaxy_tosca.yaml
+++ b/examples/galaxy_tosca.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro-galaxy-tools/custom_types.yaml
 
 description: >
   TOSCA test for launching a Galaxy Server also configuring the bowtie2


### PR DESCRIPTION
- Fast configuration for Galaxy: custom type, artifact and template (need concat option enabled on orchestrator)
- Ansible role for tool dependency: indigo-dc.galaxycloud-tooldeps
- galaxy_tosca: it is now possible to configure storage size
- Reference data: cvmfs key downloaded only if cvmfs is used.
- New Tosca Template for ELIXIR-IT elastic cluster with tools and reference data.
- enable port 21 for ftp connection