### PR TITLE
Worker node with cvmfs for reference data

### DIFF
--- a/artifacts/galaxy/galaxy_wn_configure_cvmfs.yml
+++ b/artifacts/galaxy/galaxy_wn_configure_cvmfs.yml
@@ -1,6 +1,11 @@
 ---
 - hosts: localhost
   connection: local
+  pre_tasks:
+    - name: Get the cvmfs public key on node
+      get_url:
+        url: 'https://raw.githubusercontent.com/indigo-dc/Reference-data-galaxycloud-repository/master/cvmfs_server_keys/{{ refdata_cvmfs_key_file }}'
+        dest: '/tmp'
   tasks:
     - local_action: get_url url=https://raw.githubusercontent.com/indigo-dc/ansible-role-galaxycloud/master/defaults/main.yml dest=/tmp/galaxywn.yml
     - include_vars: /tmp/galaxywn.yml
@@ -18,6 +23,17 @@
       authorized_key: user={{galaxy_user}} key="{{ lookup('file', '/tmp/' + galaxy_user + '_id_rsa.pub') }}"
 
   roles:
+    - role: indigo-dc.galaxycloud-tooldeps
+      type_of_node: wn
+      GALAXY_VERSION: '{{ galaxy_version }}'
+    - role: indigo-dc.cvmfs-client
+      server_url: '{{ refdata_cvmfs_server_url }}'
+      repository_name: '{{ refdata_cvmfs_repository_name }}'
+      cvmfs_public_key: '{{ refdata_cvmfs_key_file }}'
+      proxy_url: '{{ refdata_cvmfs_proxy_url }}'
+      proxy_port: '{{ refdata_cvmfs_proxy_port }}'
+      cvmfs_mountpoint: '{{ refdata_dir }}'
+      when: get_refdata|bool
     - role: indigo-dc.nfs
       nfs_mode: 'client'
       nfs_client_imports: [{ local: "{{export_dir}}", remote: "{{export_dir}}", server_host: "{{ galaxy_front_end_ip }}" }]

--- a/artifacts/galaxy/galaxy_wn_configure_tooldeps.yml
+++ b/artifacts/galaxy/galaxy_wn_configure_tooldeps.yml
@@ -18,6 +18,9 @@
       authorized_key: user={{galaxy_user}} key="{{ lookup('file', '/tmp/' + galaxy_user + '_id_rsa.pub') }}"
 
   roles:
+    - role: indigo-dc.galaxycloud-tooldeps
+      type_of_node: wn
+      GALAXY_VERSION: '{{ galaxy_version }}'
     - role: indigo-dc.nfs
       nfs_mode: 'client'
       nfs_client_imports: [{ local: "{{export_dir}}", remote: "{{export_dir}}", server_host: "{{ galaxy_front_end_ip }}" }]

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -483,10 +483,98 @@ node_types:
     interfaces:
       Standard:
         configure:
-          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/galaxy/galaxy_wn_configure.yml
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/artifacts/galaxy/galaxy_wn_configure.yml
           inputs:
             galaxy_front_end_ip: { get_property: [ SELF, front_end_ip ] }
             export_dir: { get_property: [ SELF, export_dir ] }
+
+  tosca.nodes.indigo.GalaxyWnToolDeps:
+    derived_from: tosca.nodes.indigo.GalaxyWN
+    properties:
+      flavor:
+        type: string
+        description: name of the Galaxy flavor
+        required: true
+        default: galaxy-no-tools
+      version:
+        type: string
+        description: galaxy version installed
+        default: master
+        required: false
+    requirements:
+      - host:
+          capability: tosca.capabilities.Container
+          node: tosca.nodes.Compute
+          relationship: tosca.relationships.HostedOn
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/artifacts/galaxy/galaxy_wn_configure_tooldeps.yml
+          inputs:
+            galaxy_front_end_ip: { get_property: [ SELF, front_end_ip ] }
+            export_dir: { get_property: [ SELF, export_dir ] }
+            galaxy_flavor: { get_property: [ SELF, flavor ] }
+            galaxy_version: { get_property: [ SELF, version ] }
+
+  tosca.nodes.indigo.GalaxyWnCvmfsReferenceData:
+    derived_from: tosca.nodes.indigo.GalaxyWnToolDeps
+    properties:
+      reference_data:
+        type: boolean
+        description: Install Reference data
+        default: true
+        required: true
+      refdata_cvmfs_server_url:
+        type: string
+        description: CernVM-FS server, replica or stratum-zero
+        default: 'server_url'
+        required: false
+      refdata_cvmfs_repository_name:
+        type: string
+        description: Reference data CernVM-FS repository name
+        default: 'not_a_cvmfs_repository_name'
+        required: false
+      refdata_cvmfs_key_file:
+        type: string
+        description: CernVM-FS public key
+        default: 'not_a_key'
+        required: false
+      refdata_cvmfs_proxy_url:
+        type: string
+        description: CernVM-FS proxy url
+        default: 'DIRECT'
+        required: false
+      refdata_cvmfs_proxy_port:
+        type: integer
+        description: CernVM-FS proxy port
+        default: 80
+        required: false
+      refdata_dir:
+        type: string
+        description: path to store galaxy reference data
+        default: /refdata
+        required: false
+    requirements:
+      - host:
+          capability: tosca.capabilities.Container
+          node: tosca.nodes.Compute
+          relationship: tosca.relationships.HostedOn
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/artifacts/galaxy/galaxy_wn_configure_cvmfs.yml
+          inputs:
+            galaxy_front_end_ip: { get_property: [ SELF, front_end_ip ] }
+            export_dir: { get_property: [ SELF, export_dir ] }
+            galaxy_flavor: { get_property: [ SELF, flavor ] }
+            galaxy_version: { get_property: [ SELF, version ] }
+            get_refdata: { get_property: [ SELF, reference_data ] }
+            refdata_cvmfs_server_url: { get_property: [ SELF, refdata_cvmfs_server_url ] }
+            refdata_cvmfs_repository_name: { get_property: [ SELF, refdata_cvmfs_repository_name ] }
+            refdata_cvmfs_key_file: { get_property: [ SELF, refdata_cvmfs_key_file ] }
+            refdata_cvmfs_proxy_url: { get_property: [ SELF, refdata_cvmfs_proxy_url ] }
+            refdata_cvmfs_proxy_port: { get_property: [ SELF, refdata_cvmfs_proxy_port ] }
+            refdata_dir: { get_property: [ SELF, refdata_dir ] }
 
   tosca.nodes.indigo.GalaxyShedTool:
     derived_from: tosca.nodes.WebApplication

--- a/examples/galaxy_elastic_cluster.yaml
+++ b/examples/galaxy_elastic_cluster.yaml
@@ -64,7 +64,7 @@ topology_template:
     export_dir:
       type: string
       description: path to store galaxy data
-      default: /home/export
+      default: /export
 
   node_templates:
 

--- a/examples/galaxy_elastic_cluster.yaml
+++ b/examples/galaxy_elastic_cluster.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/custom_types.yaml
 
 description: >
   TOSCA test for launching a Virtual Elastic Cluster. It will launch

--- a/examples/galaxy_elastic_cluster_aws.yaml
+++ b/examples/galaxy_elastic_cluster_aws.yaml
@@ -43,7 +43,7 @@ topology_template:
     export_dir:
       type: string
       description: path to store galaxy data
-      default: /home/export
+      default: /export
 
     access_key:
       type: string

--- a/examples/galaxy_elastic_cluster_aws.yaml
+++ b/examples/galaxy_elastic_cluster_aws.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/custom_types.yaml
 
 description: >
   TOSCA test for launching a Virtual Elastic Cluster. It will launch

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -232,7 +232,7 @@ topology_template:
       capabilities:
         wn:
           properties:
-            max_instances: { get_input: wn_num }
+            max_instances: { get_inpu/: wn_num }
             min_instances: 0
       requirements:
         - host: lrms_wn
@@ -244,7 +244,7 @@ topology_template:
         front_end_ip: { get_attribute: [ lrms_server, private_address, 0 ] }
         galaxy_flavor: { get_input: flavor }
         galaxy_version: { get_input: version }
-        get_refdata: { get_input: reference_data }
+        reference_data: { get_input: reference_data }
         refdata_cvmfs_server_url: { get_input: refdata_cvmfs_server_url }
         refdata_cvmfs_repository_name: { get_input: refdata_cvmfs_repository_name }
         refdata_cvmfs_key_file: { get_input: refdata_cvmfs_key_file }

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -68,7 +68,7 @@ topology_template:
     export_dir:
       type: string
       description: path to store galaxy data
-      default: /home/export
+      default: /export
 
     flavor:
       type: string
@@ -82,7 +82,7 @@ topology_template:
     refdata_dir:
       type: string
       description: path to store galaxy reference data
-      default: /home/refdata
+      default: /refdata
     refdata_repository_name:
       type: string
       description: Onedata space name, CernVM-FS repository name or subdirectory downaload name

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -242,8 +242,8 @@ topology_template:
       properties:
         export_dir: { get_input: export_dir }
         front_end_ip: { get_attribute: [ lrms_server, private_address, 0 ] }
-        galaxy_flavor: { get_input: flavor }
-        galaxy_version: { get_input: version }
+        flavor: { get_input: flavor }
+        version: { get_input: version }
         reference_data: { get_input: reference_data }
         refdata_cvmfs_server_url: { get_input: refdata_cvmfs_server_url }
         refdata_cvmfs_repository_name: { get_input: refdata_cvmfs_repository_name }

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -158,7 +158,7 @@ topology_template:
     galaxy_refdata:
       type: tosca.nodes.indigo.GalaxyWnCvmfsReferenceData
       properties:
-        get_refdata: { get_input: reference_data }
+        reference_data: { get_input: reference_data }
         refdata_dir: { get_input: refdata_dir }
         flavor: { get_input: flavor }
         refdata_repository_name: { get_input: refdata_repository_name }

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -68,7 +68,7 @@ topology_template:
     export_dir:
       type: string
       description: path to store galaxy data
-      default: /export
+      default: /home/export
 
     flavor:
       type: string
@@ -82,7 +82,7 @@ topology_template:
     refdata_dir:
       type: string
       description: path to store galaxy reference data
-      default: /refdata
+      default: /home/refdata
     refdata_repository_name:
       type: string
       description: Onedata space name, CernVM-FS repository name or subdirectory downaload name
@@ -156,7 +156,7 @@ topology_template:
         - host: galaxy_portal
 
     galaxy_refdata:
-      type: tosca.nodes.indigo.GalaxyWnCvmfsReferenceData
+      type: tosca.nodes.indigo.GalaxyReferenceData
       properties:
         reference_data: { get_input: reference_data }
         refdata_dir: { get_input: refdata_dir }
@@ -232,7 +232,7 @@ topology_template:
       capabilities:
         wn:
           properties:
-            max_instances: { get_inpu/: wn_num }
+            max_instances: { get_input: wn_num }
             min_instances: 0
       requirements:
         - host: lrms_wn

--- a/examples/galaxy_elastic_cluster_elixirIT.yaml
+++ b/examples/galaxy_elastic_cluster_elixirIT.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: tosca_simple_yaml_1_0
 
 imports:
-  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/custom_types.yaml
+  - indigo_custom_types: https://raw.githubusercontent.com/indigo-dc/tosca-types/mtangaro/custom_types.yaml
 
 description: >
   TOSCA test for launching a Virtual Elastic Cluster. It will launch
@@ -156,9 +156,9 @@ topology_template:
         - host: galaxy_portal
 
     galaxy_refdata:
-      type: tosca.nodes.indigo.GalaxyReferenceData
+      type: tosca.nodes.indigo.GalaxyWnCvmfsReferenceData
       properties:
-        reference_data: { get_input: reference_data }
+        get_refdata: { get_input: reference_data }
         refdata_dir: { get_input: refdata_dir }
         flavor: { get_input: flavor }
         refdata_repository_name: { get_input: refdata_repository_name }
@@ -238,10 +238,19 @@ topology_template:
         - host: lrms_wn
 
     galaxy_wn:
-      type: tosca.nodes.indigo.GalaxyWN
+      type: tosca.nodes.indigo.GalaxyWnCvmfsReferenceData
       properties:
         export_dir: { get_input: export_dir }
         front_end_ip: { get_attribute: [ lrms_server, private_address, 0 ] }
+        galaxy_flavor: { get_input: flavor }
+        galaxy_version: { get_input: version }
+        get_refdata: { get_input: reference_data }
+        refdata_cvmfs_server_url: { get_input: refdata_cvmfs_server_url }
+        refdata_cvmfs_repository_name: { get_input: refdata_cvmfs_repository_name }
+        refdata_cvmfs_key_file: { get_input: refdata_cvmfs_key_file }
+        refdata_cvmfs_proxy_url: { get_input: refdata_cvmfs_proxy_url }
+        refdata_cvmfs_proxy_port: { get_input: refdata_cvmfs_proxy_port }
+        refdata_dir: { get_input: refdata_dir }
       requirements:
         - host: lrms_wn
 


### PR DESCRIPTION
Changelog:
1. new worker node types for tool dependency and reference data (cvmfs).
2. fix /export and /refdata path on tosca template
3. fix get_refdata variable name in tosca template.