### PR TITLE
Fixing SparkMesos type

### DIFF
--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -1610,6 +1610,7 @@ node_types:
           inputs:
             marathon_password: { get_property: [ SELF, marathon_password ] }
             zookeeper_peers: { get_property: [ SELF, zookeeper_peers ] }
+            spark_mesos_deploy_app: { get_property: [ SELF, spark_mesos_deploy_app ] }
             spark_hdfs_uri: { get_property: [ SELF, spark_hdfs_uri ] }
             spark_swift_auth_url: { get_property: [ SELF, spark_swift_auth_url ] }
             spark_mesos_swift_http_port: { get_property: [ SELF, spark_swift_http_port ] }


### PR DESCRIPTION
Adding missing input spark_mesos_deploy_app to be passed to the implementation artifact