### PR TITLE
CMS services for onedata

### DIFF
--- a/artifacts/mesos/cms_services_start.yml
+++ b/artifacts/mesos/cms_services_start.yml
@@ -5,4 +5,4 @@
     - role: indigo-dc.cms_config
       marathon_username: "{{ marathon_user }}"
       marathon_password: "{{ marathon_pass }}"
-
+      cms_input_protocol: "{{ cms_input_protocol }}"

--- a/artifacts/onedata/cms_oneclient.yml
+++ b/artifacts/onedata/cms_oneclient.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  connection: local
+  roles:
+  - role: indigo-dc.oneclient

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -1366,6 +1366,14 @@ node_types:
         type: string
         required: no
         default: 'https://dodas-tts.cloud.cnaf.infn.it'
+      oneclient_token: 
+        type: string
+        required: no
+        default: 'dummy'
+      oneprovider_name: 
+        type: string
+        required: no
+        default: 'dummy'
       master_ips:
         required: yes
         type: list
@@ -1398,6 +1406,8 @@ node_types:
             proxy_iam_endpoint: { get_property: [ SELF, iam_endpoint ] }
             proxy_credential_endpoint: { get_property: [ SELF, iam_credential_endpoint ] }
             proxy_audience: { get_property: [ SELF, audience ] }
+            oneclient_token: { get_property: [ SELF, oneclient_token ] }
+            oneprovider_name: { get_property: [ SELF, oneprovider_name ] }
     requirements:
       - host:
           capability: tosca.capabilities.indigo.MesosMaster
@@ -1448,6 +1458,22 @@ node_types:
   tosca.nodes.indigo.MesosSlave:
     derived_from: tosca.nodes.indigo.LRMS.WorkerNode.Mesos
 
+  tosca.nodes.indigo.CmsOneclient:
+    derived_from: tosca.nodes.SoftwareComponent
+    properties:
+      oneclient_pkg:
+        type: string
+        required: yes
+    artifacts:
+      oneclient_role:
+        file: indigo-dc.oneclient,dciangotdev
+        type: tosca.artifacts.AnsibleGalaxy.role
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/oneclient/artifacts/onedata/cms_oneclient.yml
+          inputs:
+            oneclient_pkg: { get_property: [ SELF, oneclient_pkg ] }
 
   tosca.nodes.indigo.CmsWnConfig:
     derived_from: tosca.nodes.SoftwareComponent


### PR DESCRIPTION
- Include onedata as option for CMS services deployment 
- Add role for the proper installation of oneclient for CMS