### PR TITLE
Add AnsibleRecipe type

### DIFF
--- a/artifacts/ansible/ansible_tasks.yml
+++ b/artifacts/ansible/ansible_tasks.yml
@@ -1,0 +1,13 @@
+---
+- hosts: localhost
+  connection: local
+  tasks:
+
+  - name: Copy ansible tasks
+    copy:
+      content: "{{ ansible_tasks | to_nice_yaml }}"
+      dest: /tmp/{{ansible_name}}_tasks.yaml
+
+  - name: Include tasks
+    include_tasks:
+      file: /tmp/{{ansible_name}}_tasks.yaml

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -264,6 +264,10 @@ artifact_types:
     derived_from: tosca.artifacts.Root
     description: Ansible Galaxy role to be deployed in the target node
 
+  tosca.artifacts.AnsibleGalaxy.collection:
+    derived_from: tosca.artifacts.Root
+    description: Ansible Galaxy collection to be installed in the target node
+
   tosca.artifacts.Deployment.Image.Container.Docker:
     derived_from: tosca.artifacts.Deployment.Image
     description: Docker Container Image

--- a/custom_types.yaml
+++ b/custom_types.yaml
@@ -2959,6 +2959,23 @@ node_types:
         type: string
         required: false
 
+  tosca.nodes.indigo.AnsibleRecipe:
+    derived_from: tosca.nodes.ec3.Application
+    properties:
+      tasks:
+        type: list
+        entry_schema:
+          type: map
+        description: The YAML Ansible task list
+        required: true
+        default: []
+    interfaces:
+      Standard:
+        configure:
+          implementation: https://raw.githubusercontent.com/indigo-dc/tosca-types/master/artifacts/ansible/ansible_tasks.yml
+          inputs:
+            ansible_tasks: { get_property: [ SELF, tasks ] }
+            ansible_name: { get_attribute: [ SELF, tosca_name ] }
 
 policy_types:
 


### PR DESCRIPTION
Add a new type to enable to embed Ansible tasks directly in the TOSCA document